### PR TITLE
Fix discovery failing when LMS doesn't provide a valid hostname

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -1,71 +1,73 @@
 use anyhow::Result;
 use log::{info, warn};
 use nom::{
+    IResult, Parser,
     bytes::{self, complete::tag},
     combinator::{flat_map, map, map_res},
     number,
     sequence::preceded,
-    IResult, Parser,
 };
-use std::time::Duration;
+use std::{net::IpAddr, time::Duration};
 use tokio::{net::UdpSocket, time::timeout};
 
 #[derive(Debug)]
 pub struct Reply {
     pub hostname: String,
-    pub ip: std::net::IpAddr,
     pub port: u16,
     #[allow(dead_code)]
     pub uuid: String,
+    #[allow(dead_code)]
     pub version: String,
 }
 
 // The LMS server can be discovered by sending a broadcast UDP packet to port 3483.
+//
 // Example of answer from LMS
 // "ENAME\u{10}myhostnameJSON\u{4}9000UUID$e9b557b8-92e2-45cd-8a95-8730ffd604a5VERS\u{5}8.3.1"
 // '$' = 36 in the ASCII table
+//
 // Each value starts with a tag, followed by the length of the value in one byte, then the value
 // itself in the next length bytes.
+//
+// See the code of LMS for details:
+// https://github.com/LMS-Community/slimserver/blob/65aa473e029f2dec35b70c14d637d27867cddd11/Slim/Networking/Discovery.pm#L113-L127
 
 /// Discover the LMS server on the local network
-pub async fn discover(reply_timeout: Duration) -> Result<Reply> {
+pub async fn discover(reply_timeout: Duration) -> Result<(IpAddr, Reply)> {
     info!("Discovering LMS server on the local network");
 
     let sock = UdpSocket::bind("0.0.0.0:0").await?;
     sock.set_broadcast(true)?;
 
-    let mut buf = [0; 1024];
-
-    let ip;
-
-    loop {
-        let response = timeout(reply_timeout, broasdcast_and_recv(&mut buf, &sock)).await;
+    let (ip, buffer) = loop {
+        let response = timeout(reply_timeout, broasdcast_and_recv(&sock)).await;
         match response {
-            Ok(Ok(found_ip)) => {
-                ip = found_ip;
-                break;
+            Ok(Ok(ip_and_buffer)) => {
+                break ip_and_buffer;
             }
             Ok(Err(e)) => return Err(e.into()),
             Err(_) => warn!("Timeout waiting for LMS reply, retrying..."),
         }
-    }
+    };
 
-    parse_reply(&buf, ip)
+    parse_reply(&buffer)
         .map(|(_, reply)| {
             info!(
-                "Found LMS server: {}:{} ({})",
-                reply.hostname, reply.port, reply.version
+                "Discovered LMS '{}' at {}:{}",
+                reply.hostname, ip, reply.port
             );
-            reply
+
+            (ip, reply)
         })
         .map_err(|error| error.to_owned().into())
 }
 
-async fn broasdcast_and_recv(buf: &mut [u8], sock: &UdpSocket) -> Result<std::net::IpAddr> {
+async fn broasdcast_and_recv(sock: &UdpSocket) -> Result<(std::net::IpAddr, [u8; 1024])> {
+    let mut buffer = [0; 1024];
     let message = "eNAME\0JSON\0UUID\0VERS\0".as_bytes();
     let _ = sock.send_to(&message, "255.255.255.255:3483").await?;
-    let (_, src) = sock.recv_from(buf).await?;
-    Ok(src.ip())
+    let (_, addr) = sock.recv_from(&mut buffer).await?;
+    Ok((addr.ip(), buffer))
 }
 
 fn parse_tag<'a>(input: &'a [u8], start_tag: &str) -> IResult<&'a [u8], String> {
@@ -95,7 +97,7 @@ fn parse_version(input: &[u8]) -> IResult<&[u8], String> {
     parse_tag(input, "VERS")
 }
 
-fn parse_reply(input: &[u8], ip: std::net::IpAddr) -> IResult<&[u8], Reply> {
+fn parse_reply(input: &[u8]) -> IResult<&[u8], Reply> {
     map(
         (parse_hostname, parse_port, parse_uuid, parse_version),
         |(hostname, port, uuid, version)| Reply {
@@ -103,7 +105,6 @@ fn parse_reply(input: &[u8], ip: std::net::IpAddr) -> IResult<&[u8], Reply> {
             port,
             uuid,
             version,
-            ip,
         },
     )
     .parse(input)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, bail, Ok, Result};
-use clap::{command, Parser};
+use anyhow::{Ok, Result, anyhow, bail};
+use clap::{Parser, command};
 use discover::discover;
 use lms::LmsClient;
 use log::{debug, info};
@@ -144,15 +144,13 @@ async fn main() -> Result<()> {
             ..
         } => (hostname.clone(), port),
         _ => {
-            let reply = timeout(
+            let (ip, reply) = timeout(
                 Duration::from_secs(options.discover_timeout),
                 discover(Duration::from_millis(options.discover_reply_timeout)),
             )
             .await??;
 
-            println!("Discovered LMS '{}' at {}:{}", reply.hostname, reply.ip, reply.port);
-
-            (reply.ip.to_string(), reply.port)
+            (ip.to_string(), reply.port)
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,30 +152,7 @@ async fn main() -> Result<()> {
 
             println!("Discovered LMS '{}' at {}:{}", reply.hostname, reply.ip, reply.port);
 
-            // Lookup the server "hostname" to see if it is actually a hostname, or just a library name
-
-            let server_ip = match tokio::net::lookup_host(reply.hostname.as_str()).await {
-                Result::Ok(mut addrs) => {
-                    if let Some(addr) = addrs.next() {
-                        addr.ip()
-                    } else {
-                        info!(
-                            "DNS lookup for server name '{}' returned no addresses, keeping discovered IP {}",
-                            reply.hostname, reply.ip
-                        );
-                        reply.ip.clone()
-                    }
-                }
-                Err(e) => {
-                    info!(
-                        "DNS lookup for server name '{}' failed: {}, keeping discovered IP {}",
-                        reply.hostname, e, reply.ip
-                    );
-                    reply.ip.clone()
-                }
-            };
-
-            (server_ip.to_string(), reply.port)
+            (reply.ip.to_string(), reply.port)
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,8 +149,33 @@ async fn main() -> Result<()> {
                 discover(Duration::from_millis(options.discover_reply_timeout)),
             )
             .await??;
-            println!("Discovered LMS at {}:{}", reply.hostname, reply.port);
-            (reply.hostname, reply.port)
+
+            println!("Discovered LMS '{}' at {}:{}", reply.hostname, reply.ip, reply.port);
+
+            // Lookup the server "hostname" to see if it is actually a hostname, or just a library name
+
+            let server_ip = match tokio::net::lookup_host(reply.hostname.as_str()).await {
+                Result::Ok(mut addrs) => {
+                    if let Some(addr) = addrs.next() {
+                        addr.ip()
+                    } else {
+                        info!(
+                            "DNS lookup for server name '{}' returned no addresses, keeping discovered IP {}",
+                            reply.hostname, reply.ip
+                        );
+                        reply.ip.clone()
+                    }
+                }
+                Err(e) => {
+                    info!(
+                        "DNS lookup for server name '{}' failed: {}, keeping discovered IP {}",
+                        reply.hostname, e, reply.ip
+                    );
+                    reply.ip.clone()
+                }
+            };
+
+            (server_ip.to_string(), reply.port)
         }
     };
 


### PR DESCRIPTION
It seems like LMS doesn't enforce that the "hostname" returned by discovery is a proper hostname, and the value is actually [just the library name](https://github.com/LMS-Community/slimserver/blob/65aa473e029f2dec35b70c14d637d27867cddd11/Slim/Networking/Discovery.pm#L115).

The result of this (when paired with non-hostname named server) is the classic `Error: Error player_count` error, except it is caused by sending requests to addresses like `http://Lyrion Music Server (Docker):31011/jsonrpc.js`.

This PR checks the hostname returned by LMS by attempting to look it up via DNS first, and falls back to using the IP of the server which replied to the discovery request when the DNS lookup fails (meaning that the "hostname" is not a hostname).

I feel like I need to include the disclaimer that I have literally never written any Rust before, so uh... sorry about that.